### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 <p align="center">
   <a href="https://github.com/lirantal/cfkit/actions?workflow=CI"><img src="https://github.com/lirantal/cfkit/workflows/CI/badge.svg" alt="build"/></a>
-  <a href="https://snyk.io/test/github/lirantal/cfkit"><img src="https://snyk.io/test/github/lirantal/cfkit/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license"/></a>
   <a href="https://github.com/lirantal/cfkit"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"/></a>
 </p>


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.