### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/lirantal/cfkit/actions?workflow=CI"><img src="https://github.com/lirantal/cfkit/workflows/CI/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/cfkit/actions/workflows/ci.yml"><img src="https://github.com/lirantal/cfkit/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license"/></a>
   <a href="https://github.com/lirantal/cfkit"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"/></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.