### PR TITLE
chore: set MERGE_READY_STATE on automerge + create dependencies label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -31,6 +31,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           # we only merge PRs with labels of "dependencies" 
           MERGE_LABELS: "automerge"
+          MERGE_READY_STATE: "clean,has_hooks,unknown"
           MERGE_REMOVE_LABELS: "automerge"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "automatic"

--- a/.github/workflows/repo-init.yml
+++ b/.github/workflows/repo-init.yml
@@ -24,3 +24,12 @@ jobs:
             --color "0075ca" \
             --description "Merge this PR automatically once checks pass" \
             --force
+      - name: Create dependencies label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "dependencies" \
+            --repo "${{ github.repository }}" \
+            --color "0366d6" \
+            --description "Pull requests that update a dependency" \
+            --force


### PR DESCRIPTION
This PR makes two related housekeeping changes:

1. **`.github/workflows/automerge.yml`** — sets the `MERGE_READY_STATE` env var to `"clean,has_hooks,unknown"` on the `automerge` job, so that PRs with branch protection check states `has_hooks` and `unknown` are still eligible for automerge alongside `clean`.

2. **`.github/workflows/repo-init.yml`** — adds a new `Create dependencies label` step to the `create-label` job so that the `dependencies` label is created automatically alongside the existing `automerge` label.

No other changes.