### PR TITLE
fix release pnpm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 10.27.0
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary
- remove the hardcoded pnpm 10.27.0 version from the release workflow
- let pnpm/action-setup resolve pnpm@11.9.0 from package.json, which satisfies devEngines.packageManager >=11.0.0

## Root cause
The release workflow supplied pnpm/action-setup with version 10.27.0 while package.json declares packageManager as pnpm@11.9.0. pnpm/action-setup fails when both versions are present and conflict.

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts f }'
- node -e check confirming pnpm@11.9.0 satisfies devEngines >=11.0.0
- rg check confirming no remaining version: 10.27.0 pin in workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hardcoded pnpm version from the release workflow so `pnpm/action-setup` uses the version in `package.json` (`pnpm@11.9.0`). This fixes the version conflict that broke releases and aligns with `devEngines.packageManager >= 11.0.0`.

- **Bug Fixes**
  - Removed `version: 10.27.0` from `.github/workflows/release.yml`; `pnpm/action-setup` now resolves from `packageManager`.
  - Verified no remaining `10.27.0` pins and that `pnpm@11.9.0` meets the engine constraint.

<sup>Written for commit 371536ba8fc4e63261b1d2a26846de033a37177a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/cfkit/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

