### PR TITLE
chore: expand markdown lint exclusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i 'docs/**' -i '.superpowers/**' -i 'node_modules' -i 'dist' -i 'packages/*/docs/*.md' '**/**.md'",
+    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i 'docs/**' -i '.superpowers/**' -i 'node_modules' -i 'dist' -i 'packages/*/docs/**' '**/**.md'",
     "test": "turbo run test",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i '**/docs/**' -i '**/node_modules/**' -i 'dist' '**/**.md'",
+    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i 'docs/**' -i '.superpowers/**' -i 'node_modules' -i 'dist' '**/**.md'",
     "test": "turbo run test",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i 'docs/**' -i '.superpowers/**' -i 'node_modules' -i 'dist' '**/**.md'",
+    "lint:markdown": "pnpm exec markdownlint -c .github/.markdownlint.yml -i 'apm_modules/**' -i '.git' -i '__tests__' -i '.github' -i '.changeset' -i 'CODE_OF_CONDUCT.md' -i 'CHANGELOG.md' -i 'docs/**' -i '.superpowers/**' -i 'node_modules' -i 'dist' -i 'packages/*/docs/*.md' '**/**.md'",
     "test": "turbo run test",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
Update `scripts.lint:markdown` to apply the repository markdownlint configuration and ignore generated, metadata, and documentation paths consistently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the `lint:markdown` script to apply the repo `markdownlint` config and consistently ignore generated/vendor and docs paths, reducing noise and speeding up linting.

Adds excludes for `apm_modules/**`, `.superpowers/**`, and `packages/*/docs/**`, and normalizes ignore patterns to `docs/**`, `node_modules`, and `dist`.

<sup>Written for commit 3be88c92d83597e51ac3f39394919af9f7aaa880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/cfkit/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

